### PR TITLE
Add atomiswave bios to bios checker

### DIFF
--- a/emu-configs/defaults/retrodeck/reference_lists/bios_checklist.cfg
+++ b/emu-configs/defaults/retrodeck/reference_lists/bios_checklist.cfg
@@ -153,3 +153,4 @@ gluck.rom^fuse/^d5869034604dbfd2c1d54170e874fd0a^ZX Spectrum^Pentagon 512K/1024 
 256s-1.rom^fuse/^643861ad34831b255bf2eb64e8b6ecb8^ZX Spectrum^Scorpion 256K ROM (Required)
 256s-2.rom^fuse/^d8ad507b1c915a9acfe0d73957082926^ZX Spectrum^Scorpion 256K ROM (Required)
 256s-3.rom^fuse/^ce0723f9bc02f4948c15d3b3230ae831^ZX Spectrum^Scorpion 256K ROM (Required)
+awbios.zip^dc/^85254fbe320ca82a768ec2c26bb08def^Atomiswave^Atomiswave bios for flycast


### PR DESCRIPTION
This will add bios check for atomiswave (implemented in flycast)
Required to run any atomiswave roms
Hashes reference: https://github.com/blueminder/flycast-dojo/blob/master/flycast_roms.json