### PR TITLE
Use createcd for PS2 .cue compression

### DIFF
--- a/functions/compression.sh
+++ b/functions/compression.sh
@@ -6,6 +6,7 @@ compress_game() {
   local file="$2"
   local filename_no_path=$(basename "$file")
   local filename_no_extension="${filename_no_path%.*}"
+  local filename_extension="${filename_no_path##*.}"
   local source_file=$(dirname "$(realpath "$file")")"/"$(basename "$file")
   local dest_file=$(dirname "$(realpath "$file")")"/""$filename_no_extension"
 
@@ -15,7 +16,11 @@ compress_game() {
       /app/bin/chdman createdvd --hunksize 2048 -i "$source_file" -o "$dest_file".chd -c zstd
     ;;
     "ps2" )
-      /app/bin/chdman createdvd -i "$source_file" -o "$dest_file".chd -c zstd
+      if [[ "$filename_extension" == "cue" ]]; then
+        /app/bin/chdman createcd -i "$source_file" -o "$dest_file".chd
+      else
+        /app/bin/chdman createdvd -i "$source_file" -o "$dest_file".chd -c zstd
+      fi
     ;;
     * )
       /app/bin/chdman createcd -i "$source_file" -o "$dest_file".chd


### PR DESCRIPTION
From Discord:
> Found another issue with compression, this time around with PS2 system specifically. It always tries to use createdvd, but the system has got quite a few of CD releases which expectedly fails. I think it’s safe to assume that .cue should be all CDs. At least I couldn’t find any exceptions in a sizable sample.

After the change, compression was tested on 6 random PS2 images (3 CD, 3 DVD). Draft until I verify the produced files on Steam Deck since I can't get PCSX2 running on my dev machine.

Log attached: [retrodeck.log](https://github.com/user-attachments/files/18061256/retrodeck.log)

UPD: Verified compressed CD images by playtesting around 10 minutes each. All good, no issues found.
