### PR TITLE
Merge latest cooker into main

### DIFF
--- a/functions/global.sh
+++ b/functions/global.sh
@@ -255,7 +255,6 @@ fi
 logs_folder="$rdhome/logs"                # The path of the logs folder, here we collect all the logs
 steamsync_folder="$rdhome/.sync"          # Folder containing all the steam sync launchers for SRM
 steamsync_folder_tmp="$rdhome/.sync-tmp"  # Temp folder containing all the steam sync launchers for SRM
-cheats_folder="$rdhome/cheats"            # Folder containing all the cheats for the emulators
 backups_folder="$rdhome/backups"          # Folder containing all the RetroDECK backups
 
 export GLOBAL_SOURCED=true

--- a/functions/prepare_component.sh
+++ b/functions/prepare_component.sh
@@ -68,7 +68,7 @@ prepare_component() {
             # Declare the global variable with the new setting value
             declare -g "$current_setting_name=$new_setting_value"
             log d "Setting: $current_setting_name=$current_setting_value"
-              if [[ ! $current_setting_name == "logs_folder" ]]; then # Don't create a logs folder normally, we want to maintain the current files exactly to not lose early-install logs.
+            if [[ ! $current_setting_name == "logs_folder" ]]; then # Don't create a logs folder normally, we want to maintain the current files exactly to not lose early-install logs.
               create_dir "$new_setting_value"
             else # Log folder-specific actions
               mv "$rd_logs_folder" "$logs_folder" # Move existing logs folder from internal to userland


### PR DESCRIPTION
This PR contains a fix for newly added paths in retrodeck.cfg not being created during the post_update process.