### PR TITLE
fix(run_game): resolve RetroArch core path for CLI launches

### DIFF
--- a/functions/run_game.sh
+++ b/functions/run_game.sh
@@ -296,7 +296,7 @@ substitute_placeholders() {
     cmd="${cmd//"%ROM%"/"'$rom_path'"}"
     cmd="${cmd//"%GAMEDIR%"/"'$rom_dir'"}"
     cmd="${cmd//"%GAMEDIRRAW%"/"'$rom_dir_raw'"}"
-    cmd="${cmd//"%CORE_RETROARCH%"/"$ra_cores_path"}"
+    cmd="${cmd//"%CORE_RETROARCH%"/"$XDG_CONFIG_HOME/retroarch/cores"}"
 
     # Log the result
     log d "Command after placeholders substitutions: $cmd"


### PR DESCRIPTION
## Summary

- resolve `%CORE_RETROARCH%` from RetroDECK's XDG configuration directory
- prevent CLI game launches from collapsing the core path to `/mgba_libretro.so`
- match the persistent RetroArch core directory used by RetroDECK's ES-DE rules

## Problem

`functions/run_game.sh` replaces `%CORE_RETROARCH%` with `$ra_cores_path`, but `ra_cores_path` is not initialized anywhere on the current `main` branch. When a game is launched through RetroDECK's CLI path, a command such as:

```text
%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/mgba_libretro.so %ROM%
```

is currently reduced to:

```text
/app/retrodeck/components/retroarch/component_launcher.sh -L /mgba_libretro.so <rom>
```

RetroArch then exits because the core cannot be found. Normal ES-DE launches are unaffected because ES-DE performs its own placeholder resolution.

The active `0.11.0` branch has a broader placeholder resolver that reads core paths from `es_find_rules.xml`. This is a minimal fix for the released `main` implementation and resolves to the same persistent RetroArch core location.

## Verification

- `bash -n` passes on the staged script.
- `git diff --check` passes.
- Tested the patched substitution inside a RetroDECK 0.10.9b Flatpak.
- Confirmed `$XDG_CONFIG_HOME/retroarch/cores/mgba_libretro.so` exists in that Flatpak.
- Confirmed the generated command contains the full mGBA core path and no unresolved `%CORE_RETROARCH%` token.

